### PR TITLE
Fix for CWE-918: Server-Side Request Forgery (SSRF)

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -6,9 +6,9 @@
 import fs = require('fs')
 import { type Request, type Response, type NextFunction } from 'express'
 import logger from '../lib/logger'
-
 import { UserModel } from '../models/user'
 import * as utils from '../lib/utils'
+import { URL } from 'url'
 const security = require('../lib/insecurity')
 const request = require('request')
 
@@ -16,6 +16,13 @@ module.exports = function profileImageUrlUpload () {
   return (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
+      const parsedUrl = new URL(url)
+      const trustedDomains = ['trusted1.com', 'trusted2.com'] // Add your trusted domains here
+
+      if (!trustedDomains.includes(parsedUrl.hostname)) {
+        return next(new Error('Invalid domain.'))
+      }
+
       if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {


### PR DESCRIPTION
[Corgea](https://www.corgea.com) is an AI security engineer that fixes vulnerable code.

It issued this PR to fix a vulnerability for you to review.

[See the issue and fix in Corgea.](http://localhost:8030/issue/37486b22-74a9-433d-aca3-376434c95bf6)

### Explanation of the issue
CWE-918: Server-Side Request Forgery (SSRF)
The web server receives a URL or similar request from an upstream component and retrieves the contents of this URL, but it does not sufficiently ensure that the request is being sent to the expected destination.
By providing URLs to unexpected hosts or ports, attackers can make it appear that the server is sending the request, possibly bypassing access controls such as firewalls that prevent the attackers from accessing the URLs directly. The server can be used as a proxy to conduct port scanning of hosts in internal networks, use other URLs such as that can access documents on the system (using file://), or use other protocols such as gopher:// or tftp://, which may provide greater control over the contents of requests.

### Explanation of the fix
The fix involves validating the domain of the provided URL against a list of trusted domains before processing the request, thus preventing Server-Side Request Forgery (SSRF).
- The URL module is imported to parse the incoming URL.
- A list of trusted domains is created. This list should be updated with all domains that are considered safe.
- The hostname of the incoming URL is extracted using the URL module and checked against the list of trusted domains.
- If the hostname is not in the trusted domains list, an error is thrown and the request is not processed further.
- This validation ensures that only URLs from trusted domains are processed, preventing SSRF attacks where the server could be tricked into making requests to untrusted or malicious URLs.